### PR TITLE
Feat/svc/back/aladin 알라딘 API 연동

### DIFF
--- a/src/main/java/com/book/book_log/config/AladinApiProperties.java
+++ b/src/main/java/com/book/book_log/config/AladinApiProperties.java
@@ -1,0 +1,15 @@
+package com.book.book_log.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "aladin.api")
+public class AladinApiProperties {
+    private String key;
+    private String baseUrl;
+}

--- a/src/main/java/com/book/book_log/config/SecurityConfig.java
+++ b/src/main/java/com/book/book_log/config/SecurityConfig.java
@@ -19,7 +19,8 @@ public class SecurityConfig {
                                 "/v3/api-docs.yaml",     // OpenAPI YAML
                                 "/api/auth/kakao-login/**", // 카카오 로그인 엔드포인트
                                 "/login/oauth2/**", // Spring Security OAuth2 로그인 리다이렉트
-                                "/api/auth/issue-token" // JWT 발급 엔드포인트 허용
+                                "/api/auth/issue-token", // JWT 발급 엔드포인트 허용
+                                "/api/books/**" // 도서 검색 API 인증 없이 허용
                         ).permitAll()                // 인증 없이 허용
                         .anyRequest().authenticated()    // 나머지 요청은 인증 필요
                 )

--- a/src/main/java/com/book/book_log/controller/BookController.java
+++ b/src/main/java/com/book/book_log/controller/BookController.java
@@ -1,0 +1,21 @@
+package com.book.book_log.controller;
+
+import com.book.book_log.dto.AladinBookResponseDTO;
+import com.book.book_log.service.AladinApiService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class BookController {
+    private final AladinApiService aladinApiService;
+
+    @GetMapping("api/books/search")
+    public ResponseEntity<AladinBookResponseDTO> searchBooks(@RequestParam String query) {
+        AladinBookResponseDTO response = aladinApiService.searchBooks(query);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/book/book_log/dto/AladinBookResponseDTO.java
+++ b/src/main/java/com/book/book_log/dto/AladinBookResponseDTO.java
@@ -1,0 +1,22 @@
+package com.book.book_log.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+public class AladinBookResponseDTO {
+    private String version;
+    private String title;
+    private List<BookItem> item;
+
+    @Getter
+    @Setter
+    public static class BookItem {
+        private String title; // 책 제목
+        private String author; // 저자
+        private String publisher; // 출판사
+        private String cover; // 책 표지 URL
+        private String isbn; // ISBN
+    }
+}

--- a/src/main/java/com/book/book_log/dto/AladinBookResponseDTO.java
+++ b/src/main/java/com/book/book_log/dto/AladinBookResponseDTO.java
@@ -1,17 +1,21 @@
 package com.book.book_log.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.util.List;
 
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true) // 정의되지 않은 필드 무시
 public class AladinBookResponseDTO {
-    private String version;
     private String title;
     private List<BookItem> item;
 
     @Getter
     @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class BookItem {
         private String title; // 책 제목
         private String author; // 저자

--- a/src/main/java/com/book/book_log/service/AladinApiService.java
+++ b/src/main/java/com/book/book_log/service/AladinApiService.java
@@ -2,6 +2,7 @@ package com.book.book_log.service;
 
 import com.book.book_log.config.AladinApiProperties;
 import com.book.book_log.dto.AladinBookResponseDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -10,6 +11,8 @@ import org.springframework.web.client.RestTemplate;
 @RequiredArgsConstructor
 public class AladinApiService {
     private final AladinApiProperties aladinApiProperties;
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper(); // JSON 변환을 위한 ObjectMapper
 
     public AladinBookResponseDTO searchBooks(String query) {
         String url = String.format(
@@ -17,9 +20,12 @@ public class AladinApiService {
                 aladinApiProperties.getBaseUrl(), aladinApiProperties.getKey(), query
         );
 
-        RestTemplate restTemplate = new RestTemplate();
         try {
-            return restTemplate.getForObject(url, AladinBookResponseDTO.class);
+            // 먼저 String 타입으로 응답을 받아온다.
+            String jsonResponse = restTemplate.getForObject(url, String.class);
+
+            // JSON 문자열을 AladinBookResponseDTO 객체로 변환한다.
+            return objectMapper.readValue(jsonResponse, AladinBookResponseDTO.class);
         } catch (Exception e) {
             throw new RuntimeException("알라딘 API 호출 중 오류 발생: " + e.getMessage(), e);
         }

--- a/src/main/java/com/book/book_log/service/AladinApiService.java
+++ b/src/main/java/com/book/book_log/service/AladinApiService.java
@@ -1,0 +1,27 @@
+package com.book.book_log.service;
+
+import com.book.book_log.config.AladinApiProperties;
+import com.book.book_log.dto.AladinBookResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class AladinApiService {
+    private final AladinApiProperties aladinApiProperties;
+
+    public AladinBookResponseDTO searchBooks(String query) {
+        String url = String.format(
+                "%sItemSearch.aspx?ttbkey=%s&Query=%s&SearchTarget=Book&output=js",
+                aladinApiProperties.getBaseUrl(), aladinApiProperties.getKey(), query
+        );
+
+        RestTemplate restTemplate = new RestTemplate();
+        try {
+            return restTemplate.getForObject(url, AladinBookResponseDTO.class);
+        } catch (Exception e) {
+            throw new RuntimeException("알라딘 API 호출 중 오류 발생: " + e.getMessage(), e);
+        }
+    }
+}


### PR DESCRIPTION
feat/svc/back/aladin;  알라딘 API 연동 및 도서 검색 기능 구현

- [AladinApiProperties] 알라딘 API 키 및 기본 URL 설정 추가
- [AladinApiService] 알라딘 API 호출을 통한 도서 검색 서비스 구현
- [AladinBookResponseDTO] 알라딘 API 응답 데이터 매핑을 위한 DTO 추가
- [BookController] 도서 검색 API 엔드포인트 추가 (/api/books/search)


feat/svc/back/aladin;  알라딘 API 연동 개선 및 보안 설정 수정

- [SecurityConfig] 알라딘 API 엔드포인트(`/api/books/**`) 접근 허용 추가
- [AladinApiService] RestTemplate을 이용한 API 호출 및 JSON 파싱 로직 수정
- [AladinBookResponseDTO] @JsonIgnoreProperties(ignoreUnknown = true) 추가하여 예상치 못한 필드로 인한 오류 방지