### PR TITLE
feat/svc/back/book; Book 엔티티 및 도서 조회 기능 추가

### DIFF
--- a/src/main/java/com/book/book_log/controller/BookController.java
+++ b/src/main/java/com/book/book_log/controller/BookController.java
@@ -1,21 +1,40 @@
 package com.book.book_log.controller;
 
 import com.book.book_log.dto.AladinBookResponseDTO;
+import com.book.book_log.dto.BookResponseDTO;
 import com.book.book_log.service.AladinApiService;
+import com.book.book_log.service.BookService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
+@RequestMapping("/api/books")
 @RequiredArgsConstructor
 public class BookController {
-    private final AladinApiService aladinApiService;
+    private final AladinApiService aladinApiSvc;
+    private final BookService bookSvc;
 
-    @GetMapping("api/books/search")
+    // 알라딘 API를 이용한 도서 검색
+    @GetMapping("/search")
     public ResponseEntity<AladinBookResponseDTO> searchBooks(@RequestParam String query) {
-        AladinBookResponseDTO response = aladinApiService.searchBooks(query);
+        AladinBookResponseDTO response = aladinApiSvc.searchBooks(query);
         return ResponseEntity.ok(response);
+    }
+
+    // 모든 책 조회
+    @GetMapping
+    public ResponseEntity<List<BookResponseDTO>> getAllBooks() {
+        List<BookResponseDTO> books = bookSvc.getAllBooks();
+        return ResponseEntity.ok(books);
+    }
+
+    // 특정 책 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<BookResponseDTO> getBookById(@PathVariable String id) {
+        BookResponseDTO book = bookSvc.getBookById(id);
+        return ResponseEntity.ok(book);
     }
 }

--- a/src/main/java/com/book/book_log/dto/BookResponseDTO.java
+++ b/src/main/java/com/book/book_log/dto/BookResponseDTO.java
@@ -1,0 +1,36 @@
+package com.book.book_log.dto;
+
+import com.book.book_log.entity.Book;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class BookResponseDTO {
+    private String id;
+    private String title;
+    private String author;
+    private String publisher;
+    private String coverUrl;
+    private String genreName;
+
+    // 직접 필드를 설정하는 방식
+    public BookResponseDTO(String id, String title, String author, String publisher, String coverUrl, String genreName) {
+        this.id = id;
+        this.title = title;
+        this.author = author;
+        this.publisher = publisher;
+        this.coverUrl = coverUrl;
+        this.genreName = genreName;
+    }
+
+    // Book 엔티티를 직접 받아서 DTO로 변환하는 생성자 추가
+    public BookResponseDTO(Book book) {
+        this.id = book.getId();
+        this.title = book.getTitle();
+        this.author = book.getAuthor();
+        this.publisher = book.getPublisher();
+        this.coverUrl = book.getCoverUrl();
+        this.genreName = book.getGenre() != null ? book.getGenre().getName() : null; // Genre가 null일 경우 대비
+    }
+}

--- a/src/main/java/com/book/book_log/entity/Book.java
+++ b/src/main/java/com/book/book_log/entity/Book.java
@@ -1,0 +1,35 @@
+package com.book.book_log.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.UuidGenerator;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "book")
+public class Book {
+    @Id
+    @UuidGenerator
+    @Column(length = 36, unique = true, nullable = false, updatable = false)
+    private String id;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(nullable = false, length = 100)
+    private String author;
+
+    @Column(nullable = false, length = 100)
+    private String publisher;
+
+    @Column(length = 255)
+    private String coverUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "genre_id", nullable = false)
+    private Genre genre;
+}

--- a/src/main/java/com/book/book_log/repository/BookRepository.java
+++ b/src/main/java/com/book/book_log/repository/BookRepository.java
@@ -1,0 +1,7 @@
+package com.book.book_log.repository;
+
+import com.book.book_log.entity.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookRepository extends JpaRepository<Book, String> {
+}

--- a/src/main/java/com/book/book_log/service/BookService.java
+++ b/src/main/java/com/book/book_log/service/BookService.java
@@ -1,0 +1,27 @@
+package com.book.book_log.service;
+
+import com.book.book_log.dto.BookResponseDTO;
+import com.book.book_log.entity.Book;
+import com.book.book_log.repository.BookRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BookService {
+    private final BookRepository bookRepo;
+
+    public List<BookResponseDTO> getAllBooks() {
+        List<Book> books = bookRepo.findAll();
+        return books.stream().map(BookResponseDTO::new).collect(Collectors.toList());
+    }
+
+    public BookResponseDTO getBookById(String id) {
+        Book book = bookRepo.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 책을 찾을 수 없습니다: " + id));
+        return new BookResponseDTO(book);
+    }
+}


### PR DESCRIPTION
- Book 엔티티 추가
  - id (UUID), 제목, 저자, 출판사, 장르, 표지 URL 필드 포함
  - Genre 엔티티와 ManyToOne 관계 설정 (추후 구현 예정)

- BookRepository 추가
  - 기본적인 JPA 기능 제공

- BookResponseDTO 추가
  - Book 엔티티 데이터를 DTO로 변환하여 반환

- BookService 추가
  - 전체 도서 조회 메서드 구현
  - 개별 도서 조회 메서드 구현

- BookController 수정
  - /api/books: 전체 도서 조회
  - /api/books/{id}: 특정 도서 조회