### PR TITLE
feat/svc/back/genre

### DIFF
--- a/src/main/java/com/book/book_log/controller/GenreController.java
+++ b/src/main/java/com/book/book_log/controller/GenreController.java
@@ -1,0 +1,33 @@
+package com.book.book_log.controller;
+
+import com.book.book_log.dto.GenreResponseDTO;
+import com.book.book_log.service.GenreService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/genres")
+@RequiredArgsConstructor
+public class GenreController {
+    private final GenreService genreSvc;
+
+    // 모든 장르 조회
+    @GetMapping
+    public ResponseEntity<List<GenreResponseDTO>> getAllGenres() {
+        List<GenreResponseDTO> genres = genreSvc.getAllGenres();
+        return ResponseEntity.ok(genres);
+    }
+
+    // 특정 장르 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<GenreResponseDTO> getGenreById(@PathVariable String id) {
+        GenreResponseDTO genre = genreSvc.getGenreById(id);
+        return ResponseEntity.ok(genre);
+    }
+}

--- a/src/main/java/com/book/book_log/controller/GenreController.java
+++ b/src/main/java/com/book/book_log/controller/GenreController.java
@@ -4,10 +4,7 @@ import com.book.book_log.dto.GenreResponseDTO;
 import com.book.book_log.service.GenreService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -28,6 +25,13 @@ public class GenreController {
     @GetMapping("/{id}")
     public ResponseEntity<GenreResponseDTO> getGenreById(@PathVariable String id) {
         GenreResponseDTO genre = genreSvc.getGenreById(id);
+        return ResponseEntity.ok(genre);
+    }
+
+    // 특정 장르 이름으로 조회
+    @GetMapping("/search")
+    public ResponseEntity<GenreResponseDTO> getGenreByName(@RequestParam String name) {
+        GenreResponseDTO genre = genreSvc.getGenreByName(name);
         return ResponseEntity.ok(genre);
     }
 }

--- a/src/main/java/com/book/book_log/dto/GenreResponseDTO.java
+++ b/src/main/java/com/book/book_log/dto/GenreResponseDTO.java
@@ -1,0 +1,22 @@
+package com.book.book_log.dto;
+
+import com.book.book_log.entity.Genre;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class GenreResponseDTO {
+    private String id;
+    private String name;
+    private List<GenreResponseDTO> subGenres;
+
+    public GenreResponseDTO(Genre genre) {
+        this.id = genre.getId();
+        this.name = genre.getName();
+        this.subGenres = genre.getSubGenres().stream()
+                .map(GenreResponseDTO::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/book/book_log/entity/Genre.java
+++ b/src/main/java/com/book/book_log/entity/Genre.java
@@ -1,0 +1,32 @@
+package com.book.book_log.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "genre")
+public class Genre {
+    @Id
+    @UuidGenerator
+    @Column(length = 36, unique = true, nullable = false, updatable = false)
+    private String id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Genre parent; // 상위 장르(nullable 가능)
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
+    private List<Genre> subGenres = new ArrayList<>(); // 하위 장르 목록
+}

--- a/src/main/java/com/book/book_log/repository/GenreRepository.java
+++ b/src/main/java/com/book/book_log/repository/GenreRepository.java
@@ -3,5 +3,9 @@ package com.book.book_log.repository;
 import com.book.book_log.entity.Genre;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface GenreRepository extends JpaRepository<Genre, String> {
+    // 이름으로 장르 찾기
+    Optional<Genre> findByName(String name);
 }

--- a/src/main/java/com/book/book_log/repository/GenreRepository.java
+++ b/src/main/java/com/book/book_log/repository/GenreRepository.java
@@ -1,0 +1,7 @@
+package com.book.book_log.repository;
+
+import com.book.book_log.entity.Genre;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GenreRepository extends JpaRepository<Genre, String> {
+}

--- a/src/main/java/com/book/book_log/service/GenreService.java
+++ b/src/main/java/com/book/book_log/service/GenreService.java
@@ -29,4 +29,11 @@ public class GenreService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 장르를 찾을 수 없습니다: " + id));
         return new GenreResponseDTO(genre);
     }
+
+    // 특정 장르 조회(이름 기반)
+    public GenreResponseDTO getGenreByName(String name) {
+        Genre genre = genreRepo.findByName(name)
+                .orElseThrow(() -> new IllegalArgumentException("해당 장르를 찾을 수 없습니다: " + name));
+        return new GenreResponseDTO(genre);
+    }
 }

--- a/src/main/java/com/book/book_log/service/GenreService.java
+++ b/src/main/java/com/book/book_log/service/GenreService.java
@@ -1,0 +1,32 @@
+package com.book.book_log.service;
+
+import com.book.book_log.dto.GenreResponseDTO;
+import com.book.book_log.entity.Genre;
+import com.book.book_log.repository.GenreRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class GenreService {
+    private final GenreRepository genreRepo;
+
+    // 모든 장르 조회
+    public List<GenreResponseDTO> getAllGenres() {
+        List<Genre> genres = genreRepo.findAll();
+        return genres.stream()
+                .map(GenreResponseDTO::new)
+                .collect(Collectors.toList());
+    }
+
+    // 특정 장르 조회
+    public GenreResponseDTO getGenreById(String id) {
+        Genre genre = genreRepo.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 장르를 찾을 수 없습니다: " + id));
+        return new GenreResponseDTO(genre);
+    }
+}


### PR DESCRIPTION
### feat/svc/back/genre; Genre 엔티티 및 관련 기능 추가

- Genre 엔티티 추가
  - id(UUID), name, parent(자기 참조) 필드 정의
  - 하위 장르 리스트 필드(subGenres) 추가

- GenreRepository 추가
  - JPA를 활용한 기본 CRUD 기능 제공

- GenreResponseDTO 추가
  - Genre 엔티티의 데이터를 DTO로 변환
  - 하위 장르 리스트(subGenres) 포함

- GenreService 추가
  - getAllGenres: 모든 장르 조회 기능 구현
  - getGenreById: 특정 장르 조회 기능 구현

- GenreController 추가
  - /api/genres: 모든 장르 조회 API 추가
  - /api/genres/{id}: 특정 장르 조회 API 추가
  <br/>

### feat/svc/back/genre-search; 장르명으로 조회 API 추가

- GenreController 수정
  - /api/genres/search?name={장르명} 엔드포인트 추가
  - 장르명을 기준으로 특정 장르 조회 가능
  
- GenreService 수정
  - findGenreByName 메서드 추가
  - 장르명을 기준으로 데이터베이스에서 장르 검색

- GenreRepository 수정
  - findByName(String name) 메서드 추가
  - 장르명을 통해 특정 장르 조회 가능