### PR TITLE
feat/svc/back/log; Log 엔티티 및 API 구현

### DIFF
--- a/src/main/java/com/book/book_log/config/SecurityConfig.java
+++ b/src/main/java/com/book/book_log/config/SecurityConfig.java
@@ -21,7 +21,8 @@ public class SecurityConfig {
                                 "/login/oauth2/**", // Spring Security OAuth2 로그인 리다이렉트
                                 "/api/auth/issue-token", // JWT 발급 엔드포인트 허용
                                 "/api/books/**", // 도서 검색 API 인증 없이 허용
-                                "/api/categories/**" // 카테고리 검색 인증 없이 활용
+                                "/api/categories/**", // 카테고리 검색 인증 없이 활용
+                                "/api/logs/**" // 로그 API 인증 없이 허용
                         ).permitAll()                // 인증 없이 허용
                         .anyRequest().authenticated()    // 나머지 요청은 인증 필요
                 )

--- a/src/main/java/com/book/book_log/controller/LogController.java
+++ b/src/main/java/com/book/book_log/controller/LogController.java
@@ -1,0 +1,47 @@
+package com.book.book_log.controller;
+
+import com.book.book_log.dto.LogRequestDTO;
+import com.book.book_log.dto.LogResponseDTO;
+import com.book.book_log.service.LogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/logs")
+@RequiredArgsConstructor
+public class LogController {
+    private final LogService logSvc;
+
+    // Log 작성
+    @PostMapping("/{userId}")
+    public ResponseEntity<LogResponseDTO> createLog(@PathVariable String userId,
+                                                    @RequestBody LogRequestDTO request) {
+        LogResponseDTO log = logSvc.createLog(userId, request);
+        return ResponseEntity.ok(log);
+    }
+
+    // 특정 책에 대한 Log 조회
+    @GetMapping("/book/{bookId}")
+    public ResponseEntity<List<LogResponseDTO>> getLogsByBookId(@PathVariable String bookId) {
+        List<LogResponseDTO> logs = logSvc.getLogsByBookId(bookId);
+        return ResponseEntity.ok(logs);
+    }
+
+    // Log 수정
+    @PatchMapping("/{logId}")
+    public ResponseEntity<LogResponseDTO> updateLog(@PathVariable String logId,
+                                                    @RequestBody LogRequestDTO request) {
+        LogResponseDTO log = logSvc.updateLog(logId, request);
+        return ResponseEntity.ok(log);
+    }
+
+    // Log 삭제
+    @DeleteMapping("/{logId}")
+    public ResponseEntity<Void> deleteLog(@PathVariable String logId) {
+        logSvc.deleteLog(logId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/book/book_log/dto/LogRequestDTO.java
+++ b/src/main/java/com/book/book_log/dto/LogRequestDTO.java
@@ -1,0 +1,22 @@
+package com.book.book_log.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class LogRequestDTO {
+    private String bookTitle;
+    private String author;
+    private String publisher;
+    private Integer categoryId;
+    private String coverUrl;
+    private Float rating;
+    private String quote;
+    private String content;
+    private Boolean visibility;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/src/main/java/com/book/book_log/dto/LogResponseDTO.java
+++ b/src/main/java/com/book/book_log/dto/LogResponseDTO.java
@@ -1,0 +1,38 @@
+package com.book.book_log.dto;
+
+import com.book.book_log.entity.Log;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+public class LogResponseDTO {
+    private String id;
+    private String userId;
+    private String bookId;
+    private String bookTitle;
+    private Float rating;
+    private String quote;
+    private String content;
+    private Boolean visibility;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public LogResponseDTO(Log log) {
+        this.id = log.getId();
+        this.userId = log.getUser().getId();
+        this.bookId = log.getBook().getId();
+        this.bookTitle = log.getBook().getTitle();
+        this.rating = log.getRating();
+        this.quote = log.getQuote();
+        this.content = log.getContent();
+        this.visibility = log.getVisibility();
+        this.startDate = log.getStartDate();
+        this.endDate = log.getEndDate();
+        this.createdAt = log.getCreatedAt();
+        this.updatedAt = log.getUpdatedAt();
+    }
+}

--- a/src/main/java/com/book/book_log/entity/Book.java
+++ b/src/main/java/com/book/book_log/entity/Book.java
@@ -6,6 +6,9 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.UuidGenerator;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -31,4 +34,7 @@ public class Book {
 
     @Column(nullable = false)
     private Integer categoryId;
+
+    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Log> logs = new ArrayList<>();
 }

--- a/src/main/java/com/book/book_log/entity/Log.java
+++ b/src/main/java/com/book/book_log/entity/Log.java
@@ -1,0 +1,65 @@
+package com.book.book_log.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "log")
+public class Log {
+    @Id
+    @UuidGenerator
+    @Column(length = 36, unique = true, nullable = false, updatable = false)
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id", nullable = false)
+    private Book book;
+
+    @Column(nullable = false)
+    private Float rating;
+
+    @Column(length = 255)
+    private String quote;
+
+    @Lob
+    private String content;
+
+    @Column(nullable = false)
+    private Boolean visibility = true; // 기본값: 공개
+
+    @Column(nullable = false)
+    private LocalDate startDate; // 독서 시작일
+
+    @Column(nullable = false)
+    private LocalDate endDate; // 독서 종료일
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = createdAt;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/book/book_log/entity/User.java
+++ b/src/main/java/com/book/book_log/entity/User.java
@@ -11,6 +11,8 @@ import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.annotations.UuidGenerator;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -61,4 +63,7 @@ public class User {
     @UpdateTimestamp
     @Column(nullable = false)
     private LocalDateTime updatedAt;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Log> logs = new ArrayList<>();
 }

--- a/src/main/java/com/book/book_log/repository/BookRepository.java
+++ b/src/main/java/com/book/book_log/repository/BookRepository.java
@@ -4,7 +4,14 @@ import com.book.book_log.entity.Book;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BookRepository extends JpaRepository<Book, String> {
     List<Book> findByCategoryId(Integer categoryId);
+
+    /**
+     * 제목과 저자가 동일한 책이 존재하는지 확인
+     * Log 작성 시 중복 저장을 방지하기 위해 사용됨
+     */
+    Optional<Book> findByTitleAndAuthor(String title, String author);
 }

--- a/src/main/java/com/book/book_log/repository/LogRepository.java
+++ b/src/main/java/com/book/book_log/repository/LogRepository.java
@@ -1,0 +1,10 @@
+package com.book.book_log.repository;
+
+import com.book.book_log.entity.Log;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface LogRepository extends JpaRepository<Log, String> {
+    List<Log> findByBookId(String bookId);
+}

--- a/src/main/java/com/book/book_log/service/LogService.java
+++ b/src/main/java/com/book/book_log/service/LogService.java
@@ -1,0 +1,99 @@
+package com.book.book_log.service;
+
+import com.book.book_log.dto.LogRequestDTO;
+import com.book.book_log.dto.LogResponseDTO;
+import com.book.book_log.entity.Book;
+import com.book.book_log.entity.Log;
+import com.book.book_log.entity.User;
+import com.book.book_log.repository.BookRepository;
+import com.book.book_log.repository.LogRepository;
+import com.book.book_log.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class LogService {
+    private final LogRepository logRepo;
+    private final BookRepository bookRepo;
+    private final UserRepository userRepo;
+
+    // Log 생성(Book 자동 저장)
+    @Transactional
+    public LogResponseDTO createLog(String userId, LogRequestDTO request) {
+        User user = userRepo.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다." + userId));
+
+        // 책이 DB에 없으면 자동 저장
+        Book book = bookRepo.findByTitleAndAuthor(request.getBookTitle(), request.getAuthor())
+                .orElseGet(() -> {
+                    Book newBook = new Book();
+                    newBook.setTitle(request.getBookTitle());
+                    newBook.setAuthor(request.getAuthor());
+                    newBook.setPublisher(request.getPublisher());
+                    newBook.setCategoryId(request.getCategoryId());
+                    newBook.setCoverUrl(request.getCoverUrl());
+                    return bookRepo.save(newBook);
+                });
+
+        // 별점 검증 (1~5, 0.5 단위)
+        validateRating(request.getRating());
+
+        // Log 저장
+        Log log = new Log();
+        log.setUser(user);
+        log.setBook(book);
+        log.setRating(request.getRating());
+        log.setQuote(request.getQuote());
+        log.setContent(request.getContent());
+        log.setVisibility(request.getVisibility() != null ? request.getVisibility() : true);
+        log.setStartDate(request.getStartDate());
+        log.setEndDate(request.getEndDate());
+
+        return new LogResponseDTO(logRepo.save(log));
+    }
+
+    // 특정 책에 대한 Log 목록 조회
+    public List<LogResponseDTO> getLogsByBookId(String bookId) {
+        List<Log> logs = logRepo.findByBookId(bookId);
+        return logs.stream().map(LogResponseDTO::new).collect(Collectors.toList());
+    }
+
+    // Log 수정
+    @Transactional
+    public LogResponseDTO updateLog(String logId, LogRequestDTO request) {
+        Log log = logRepo.findById(logId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 Log를 찾을 수 없습니다: " + logId));
+
+        validateRating(request.getRating());
+
+        log.setRating(request.getRating());
+        log.setQuote(request.getQuote());
+        log.setContent(request.getContent());
+        log.setVisibility(request.getVisibility());
+        log.setStartDate(request.getStartDate());
+        log.setEndDate(request.getEndDate());
+
+        return new LogResponseDTO(logRepo.save(log));
+    }
+
+    // Log 삭제
+    @Transactional
+    public void deleteLog(String logId) {
+        if (!logRepo.existsById(logId)) {
+            throw new IllegalArgumentException("해당 Log를 찾을 수 없습니다: " + logId);
+        }
+        logRepo.deleteById(logId);
+    }
+
+    // 별점 검증 로직 (1~5 범위, 0.5 단위)
+    private void validateRating(Float rating) {
+        if (rating == null || rating < 1 || rating > 5 || rating % 0.5 != 0) {
+            throw new IllegalArgumentException("별점은 1~5 범위에서 0.5 단위로 입력해야 합니다.");
+        }
+    }
+}


### PR DESCRIPTION
- Log 엔티티 및 관련 기능 추가
  - Log 엔티티 추가 (사용자 독서 기록 저장)
  - LogRequestDTO, LogResponseDTO 추가 (요청 및 응답 데이터 처리)
  - LogRepository 추가 (데이터베이스 CRUD 지원)
  - LogService 추가 (로그 작성, 조회, 수정, 삭제 로직 구현)
  - LogController 추가 (RESTful API 엔드포인트 구현)

- Book 엔티티 수정
  - User와 Log 관계 설정 (OneToMany 추가)
  - Log와 Book 관계 설정 (OneToMany 추가)
  - BookRepository 수정 (findByTitleAndAuthor 추가, 중복 저장 방지)

- SecurityConfig 수정
  - `/api/logs/**` 엔드포인트 인증 없이 접근 가능하도록 설정

- User 엔티티 수정
  - User와 Log의 관계 매핑 추가 (OneToMany 관계 설정)