### PR TITLE
fix/swagger; Spring Boot & SpringDoc 버전 호환성 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.0'
+	id 'org.springframework.boot' version '3.2.4'
 	id 'io.spring.dependency-management' version '1.1.6'
 }
 


### PR DESCRIPTION
- spring-boot 버전을 3.4.0 → 3.2.4로 다운그레이드하여 Swagger 500 오류 해결
- Swagger UI (/swagger-ui) 정상 접근 및 API 문서 렌더링 확인

### 성공 사진
![image](https://github.com/user-attachments/assets/ce94a379-5fc9-419e-82ea-be065e6bb3bf)
