### PR TITLE
feat/infra/mongodb-init; MongoDB 연결 및 테스트용 Document 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// mongoDB 설정
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/book/book_log/config/TestDataLoader.java
+++ b/src/main/java/com/book/book_log/config/TestDataLoader.java
@@ -1,0 +1,20 @@
+package com.book.book_log.config;
+
+import com.book.book_log.entity.TestDocument;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TestDataLoader {
+    private final MongoTemplate mongoTemplate;
+
+    @PostConstruct
+    public void init() {
+        TestDocument doc = new TestDocument();
+        doc.setMessage("Hello MongoDB");
+        mongoTemplate.save(doc);
+    }
+}

--- a/src/main/java/com/book/book_log/entity/TestDocument.java
+++ b/src/main/java/com/book/book_log/entity/TestDocument.java
@@ -1,0 +1,15 @@
+package com.book.book_log.entity;
+
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@Setter
+@Document(collection = "test")
+public class TestDocument {
+    @Id
+    private String id;
+    private String message;
+}


### PR DESCRIPTION
## feat/infra/mongodb-init; MongoDB 연결 및 테스트용 Document 추가

- [TestDocument] MongoDB 컬렉션용 테스트 도큐먼트 클래스 정의
- [TestDataLoader] 애플리케이션 실행 시 테스트 도큐먼트 저장
- [build.gradle] spring-boot-starter-data-mongodb 의존성 추가
- [application.properties] MongoDB 연결 설정 추가

## 연동 확인 완료
![image](https://github.com/user-attachments/assets/f739c43f-c315-42fe-88af-4f36c0b7507d)
