### PR TITLE
fix/svc/front/booklog; 카테고리 렌더링 오류 해결

### DIFF
--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -40,5 +40,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "proxy": "http://localhost:8080"
 }

--- a/src/main/frontend/src/booklog/Booklog.jsx
+++ b/src/main/frontend/src/booklog/Booklog.jsx
@@ -184,7 +184,8 @@ function Booklog() {
             try {
                 const response = await fetch("/api/categories");
                 const data = await response.json();
-                setCategories(data.categories);
+                console.log("카테고리 응답 확인: ", data);
+                setCategories(data);
             } catch(error) {
                 console.error(error);
             }


### PR DESCRIPTION
## 문제 원인
### 1. 프론트의 응답 파싱 방식 오류
![image](https://github.com/user-attachments/assets/6e72e421-58f8-430f-b7c6-92cce69a9747)
- 백엔드에서는 /api/categories 요청에 대해 JSON 배열 형태로 응답하고 있었음.
- 그러나 프론트에서는 data.categories로 접근하고 있었고, 실제 응답은 배열 자체였기 때문에 undefined가 되어 카테고리가 렌더링되지 않음.

### 2. 프록시 미설정으로 인한 API 요청 실패
![image](https://github.com/user-attachments/assets/b012d381-81a8-438b-9e12-27d78a9c28e1)
- 프론트에서 백엔드 서버로의 API 요청이 제대로 전달되지 않아, HTML 형태의 응답을 받아 SyntaxError: Unexpected token '<' 에러가 발생.
- 이는 proxy 설정이 누락되어 발생한 문제로 확인됨.

## 수정 사항
- `setCategories(data.categories) → setCategories(data)` 로 수정하여 올바르게 응답 데이터를 처리하도록 변경
- `package.json에 "proxy": "http://localhost:8080"` 설정을 추가하여 API 요청이 백엔드로 잘 전달되도록 조치

## 성공 사진
![image](https://github.com/user-attachments/assets/2527ce83-a626-4e77-8bf0-d8fde249c6c1)
