### PR TITLE
fix/svc/back/booklog; 알라딘 API 기본 조회 수 48개로 임시 조정

### DIFF
--- a/src/main/frontend/src/booklog/Booklog.jsx
+++ b/src/main/frontend/src/booklog/Booklog.jsx
@@ -211,6 +211,10 @@ function Booklog() {
         fetchCategories();
     },[]);
 
+    useEffect(() => {
+        fetchBooks();
+    }, []);
+
     useEffect(()=> {
         fetchBooks();
     },[selectedCategory]);
@@ -253,7 +257,8 @@ function Booklog() {
             const response = await fetch(url);
             const data = await response.json();
 
-            let fetchedBooks = data.books || data.item || [];
+            console.log("응답 전체:", data);
+            let fetchedBooks = data.books || data.item || (Array.isArray(data) ? data : []) || [];
 
             if (query) {
                 const lowerQuery = query.toLowerCase();
@@ -377,7 +382,7 @@ function Booklog() {
                                         console.log("Clicked Book : ", book);
                                         navigate(`/bookdetail/${book.isbn}`);
                                     }}>
-                                    <BookImage src={book.cover} alt={book.title} />
+                                    <BookImage src={book.cover || book.coverUrl} alt={book.title} />
                                     <BookTitle>{book.title}</BookTitle>
                                     <BookAuthor>{book.author}</BookAuthor>
                                 </BookCard>

--- a/src/main/java/com/book/book_log/controller/BookController.java
+++ b/src/main/java/com/book/book_log/controller/BookController.java
@@ -27,7 +27,18 @@ public class BookController {
     // 모든 책 조회
     @GetMapping
     public ResponseEntity<List<BookResponseDTO>> getAllBooks() {
-        List<BookResponseDTO> books = bookSvc.getAllBooks();
+        AladinBookResponseDTO response = aladinApiSvc.searchBooks("베스트셀러"); // 기본 키워드
+        List<BookResponseDTO> books = response.getItem().stream()
+                .map(item -> new BookResponseDTO(
+                        null,
+                        item.getTitle(),
+                        item.getAuthor(),
+                        item.getPublisher(),
+                        item.getCover(),
+                        null
+                ))
+                .toList();
+
         return ResponseEntity.ok(books);
     }
 

--- a/src/main/java/com/book/book_log/service/AladinApiService.java
+++ b/src/main/java/com/book/book_log/service/AladinApiService.java
@@ -16,7 +16,7 @@ public class AladinApiService {
 
     public AladinBookResponseDTO searchBooks(String query) {
         String url = String.format(
-                "%sItemSearch.aspx?ttbkey=%s&Query=%s&SearchTarget=Book&output=js",
+                "%sItemSearch.aspx?ttbkey=%s&Query=%s&SearchTarget=Book&output=js&MaxResults=48",
                 aladinApiProperties.getBaseUrl(), aladinApiProperties.getKey(), query
         );
 

--- a/src/main/java/com/book/book_log/service/AladinApiService.java
+++ b/src/main/java/com/book/book_log/service/AladinApiService.java
@@ -16,6 +16,7 @@ public class AladinApiService {
 
     public AladinBookResponseDTO searchBooks(String query) {
         String url = String.format(
+                // 임시로 결과가 48개만 나오도록 설정(TODO: 페이지네이션 추가)
                 "%sItemSearch.aspx?ttbkey=%s&Query=%s&SearchTarget=Book&output=js&MaxResults=48",
                 aladinApiProperties.getBaseUrl(), aladinApiProperties.getKey(), query
         );


### PR DESCRIPTION
## 수정한 내용
- 알라딘 API 호출 시 MaxResults=48로 수정하여 응답 JSON 파싱 오류 방지
- 초기에 BookLog 페이지 진입 시 도서 목록을 안정적으로 출력하도록 개선
- 60개 이상 요청 시 JSON 파싱 오류(Unrecognized character escape)가 발생하여 임시로 48개로 고정

## 추후 수정해야 할 부분
- 도서 목록이 고정된 48개로 제한되어 있어 유동적으로 많은 책을 보고 싶은 경우 대응이 필요
- 알라딘 API의 Start와 MaxResults 파라미터를 이용해 페이지네이션 기능 추가 필요