### PR TITLE
fix/svc/kakao-login-redirect-mismatch; 카카오 로그인 시작 경로 수정 및 보안 설정 정리

### DIFF
--- a/src/main/frontend/src/header/Header.jsx
+++ b/src/main/frontend/src/header/Header.jsx
@@ -86,7 +86,7 @@ function Header() {
 
     // 카카오 로그인 리디렉트 함수
     const redirectToKakaoLogin = () => {
-        window.location.href = "http://localhost:8080/login/oauth2/code/kakao";
+        window.location.href = "http://localhost:8080/oauth2/authorization/kakao";
     };    
 
     const handleImageClick = () => {

--- a/src/main/java/com/book/book_log/config/SecurityConfig.java
+++ b/src/main/java/com/book/book_log/config/SecurityConfig.java
@@ -17,7 +17,6 @@ public class SecurityConfig {
                                 "/swagger-ui/**",       // Swagger UI 경로
                                 "/v3/api-docs/**",      // OpenAPI docs
                                 "/v3/api-docs.yaml",     // OpenAPI YAML
-                                "/api/auth/kakao-login/**", // 카카오 로그인 엔드포인트
                                 "/login/oauth2/**", // Spring Security OAuth2 로그인 리다이렉트
                                 "/api/auth/issue-token", // JWT 발급 엔드포인트 허용
                                 "/api/books/**", // 도서 검색 API 인증 없이 허용


### PR DESCRIPTION
## 발생한 문제
![image](https://github.com/user-attachments/assets/2c8a6633-9fdc-4bc6-a892-700a2dfb5583)
- 카카오 로그인 버튼 클릭 시 http://localhost:8080/api/auth/kakao-login/failure 경로로 리다이렉트됨
- 화면에 Login with OAuth 2.0, [invalid_request], kakao 메시지가 뜨며 로그인 흐름이 중단됨

## 원인
- 프론트에서 OAuth2 로그인 flow를 시작할 때 직접 redirect URI(/login/oauth2/code/kakao)로 이동하고 있었음
- 이 경로는 Spring Security의 콜백 처리 경로로, 인증 요청을 시작하는 경로가 아님

## 해결 방법
- 로그인 시작 경로를 Spring OAuth2 표준 경로인 /oauth2/authorization/kakao로 변경
- SecurityConfig에서 /api/auth/kakao-login/** 경로 허용 제거
- 이제 OAuth2 인증 flow가 정상적으로 시작되고 로그인 후 지정된 redirect URI로 이동함

## TODO
![image](https://github.com/user-attachments/assets/fdf5355a-bb49-4722-812f-c81a6cdd92a4)
회원가입이 아닌 로그인 시에도 '추가 정보 입력' 페이지로 리다이렉트 되고 있음
-> 경로 수정 필요
