### PR TITLE
feat; GitHub Actions로 Jira 상태 자동 변경 워크플로우 추가

### DIFF
--- a/.github/workflows/jira-update.yml
+++ b/.github/workflows/jira-update.yml
@@ -1,0 +1,24 @@
+name: Update Jira Issue on Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+
+jobs:
+  update-jira:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract Issue Key from Branch
+        run: |
+          echo "ISSUE_KEY=$(echo ${{ github.head_ref }} | grep -oE '[A-Z]+-[0-9]+')" >> $GITHUB_ENV
+
+      - name: Update Jira Issue Status
+        run: |
+          curl -X POST \
+            -u ${{ secrets.JIRA_USER }}:${{ secrets.JIRA_API_TOKEN }} \
+            -H "Content-Type: application/json" \
+            --data '{"transition": {"id": "51"}}' \
+            "https://${{ secrets.JIRA_DOMAIN }}/rest/api/3/issue/${ISSUE_KEY}/transitions"


### PR DESCRIPTION
### 작업 내용
- 브랜치 머지 시 Jira 티켓 상태를 자동으로 '작업 완료'로 변경하는 GitHub Actions 워크플로우(jira-update.yml) 추가
- 브랜치명에 Jira 이슈 키 포함 시 동작 (feat/ITS-1-... 등)

### 테스트 방법
- 테스트용 브랜치 생성 (feat/ITS-XX-jira-auto)
- Pull Request를 develop 브랜치에 생성 후 머지
- Jira에서 해당 이슈 상태가 자동으로 '작업 완료'로 변경되는지 확인

### 주의 사항
- Secrets(JIRA_USER, JIRA_API_TOKEN, JIRA_DOMAIN) 설정 필요
- 브랜치명에 Jira 이슈 키가 포함되어야 정상 동작