### PR TITLE
ci/github-actions; GitHub Actions CI 워크플로 및 테스트 전용 설정 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    services:
+      # TestDataLoader가 컨텍스트 로드 시 MongoTemplate.save()를 실행하므로 테스트에 Mongo 필요
+      mongodb:
+        image: mongo:7.0
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --eval 'db.runCommand({ping: 1})'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Build and test
+        run: ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'com.h2database:h2'
 
 	// mongoDB 설정
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,30 @@
+spring.application.name=book-log
+
+# 메인 application.properties는 gitignore 대상이라 CI에 존재하지 않음 → 테스트 전용 설정을 커밋
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE;DB_CLOSE_DELAY=-1
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.hibernate.ddl-auto=create-drop
+
+# data.sql이 MySQL 문법이라 H2에서 자동 실행되면 깨짐 → 비활성화
+spring.sql.init.mode=never
+
+# 로컬은 brew mongo, CI는 서비스 컨테이너 (TestDataLoader가 컨텍스트 로드 시 Mongo 접속)
+spring.data.mongodb.uri=mongodb://localhost:27017/booklog_test
+
+# Kakao OAuth 더미 값 (컨텍스트 로드용, 실제 인증 안 함)
+spring.security.oauth2.client.registration.kakao.client-id=test-client-id
+spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:8080/api/auth/kakao-login/callback
+spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.kakao.scope=profile_nickname
+
+spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
+spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
+spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
+spring.security.oauth2.client.provider.kakao.user-name-attribute=id
+
+# Aladin API 더미 값
+aladin.api.key=test-key
+aladin.api.base-url=https://www.aladin.co.kr/ttb/api/


### PR DESCRIPTION
# PR 유형

- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩터링 (refactor)
- [x] 문서/설정 (docs/chore)
- [ ] 테스트 (test)

## 개요

PR과 main push 시점에 자동으로 빌드·테스트를 돌리는 GitHub Actions CI를 추가했습니다.
지금까지는 각자 로컬에서만 테스트를 돌려서 깨진 채로 머지될 여지가 있었습니다.

## 변경 사항

- `.github/workflows/ci.yml` 추가 — `pull_request`, `push(main)` 트리거로 `./gradlew build` 실행 (JDK 17 temurin, gradle 캐시)
- mongodb 7.0 서비스 컨테이너 구성 — `TestDataLoader`가 컨텍스트 로드 시 `MongoTemplate.save()`를 호출해서 Mongo 없이는 테스트가 뜨지 않음
- `src/test/resources/application.properties` 추가 — 메인 `application.properties`가 gitignore 대상이라 CI 러너에 존재하지 않음. 테스트 전용 설정을 커밋해서 해결 (전부 더미값, 실제 키 없음)
- `build.gradle`에 `testRuntimeOnly 'com.h2database:h2'` 추가 — 테스트 DB를 H2 인메모리로 전환

## 테스트

- [x] `./gradlew test` 통과 (`--rerun-tasks`로 캐시 무시하고 재실행 확인)
- [ ] 로컬 서버 실행 확인 (필요 시)
- [ ] Swagger/Postman으로 API 동작 확인 (필요 시)

## 배운 점 / 결정 사항

- **테스트 DB를 H2로 할지 MySQL 컨테이너로 할지**: 실제 운영과 방언을 맞추려면 MySQL 서비스 컨테이너가 정확하지만, CI 시간과 설정 부담이 커서 우선 H2를 `MODE=MySQL`로 띄우는 쪽을 선택했습니다. 대신 `DATABASE_TO_LOWER`, `CASE_INSENSITIVE_IDENTIFIERS` 옵션으로 식별자 처리 차이를 맞췄습니다. 나중에 쿼리가 MySQL 전용 문법에 의존하기 시작하면 Testcontainers로 옮기는 게 맞다고 봅니다.
- **`data.sql` 비활성화**: 초기 데이터 스크립트가 MySQL 문법이라 H2에서 자동 실행 시 깨져서 `spring.sql.init.mode=never`로 껐습니다.
- **Mongo는 왜 컨테이너로 띄웠나**: `TestDataLoader`가 애플리케이션 컨텍스트 로드 시점에 Mongo에 붙기 때문에, 순수 단위 테스트가 아닌 이상 Mongo가 없으면 컨텍스트 자체가 실패합니다. 근본적으로는 `TestDataLoader`를 프로파일로 분리하는 게 더 깔끔한데, 이번 PR 범위를 넘어서 별도로 다루려 합니다.

## 관련 이슈

<!-- closes #이슈번호 -->
