### PR TITLE
fix/kakao-login; 카카오 로그인 복구 및 인증 응답 정리

### DIFF
--- a/src/main/frontend/src/header/Header.jsx
+++ b/src/main/frontend/src/header/Header.jsx
@@ -86,7 +86,7 @@ function Header() {
 
     // 카카오 로그인 리디렉트 함수
     const redirectToKakaoLogin = () => {
-        window.location.href = "http://localhost:8080/login/oauth2/code/kakao";
+        window.location.href = "http://localhost:8080/oauth2/authorization/kakao";
     };    
 
     const handleImageClick = () => {

--- a/src/main/java/com/book/book_log/config/SecurityConfig.java
+++ b/src/main/java/com/book/book_log/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.book.book_log.config;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -14,6 +15,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable()) // CSRF 비활성화
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
+                                "/swagger-ui.html",     // Swagger UI 진입 경로 (/swagger-ui/**와 별개로 매칭됨)
                                 "/swagger-ui/**",       // Swagger UI 경로
                                 "/v3/api-docs/**",      // OpenAPI docs
                                 "/v3/api-docs.yaml",     // OpenAPI YAML
@@ -29,7 +31,14 @@ public class SecurityConfig {
                 .addFilterBefore(new JwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class) // 필터 추가
                 .oauth2Login(oauth2 -> oauth2
                         .defaultSuccessUrl("/api/auth/kakao-login/success") // 로그인 성공 시 리다이렉트 경로
-                        .failureUrl("/api/auth/kakao-login/failure") // 로그인 실패 시 리다이렉트 경로
+                        // failureUrl로 지정한 경로는 DefaultLoginPageGeneratingFilter가 가로채
+                        // 기본 로그인 페이지를 렌더하므로 컨트롤러에 도달하지 않는다
+                        .failureHandler((request, response, exception) -> {
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            response.setContentType("application/json;charset=UTF-8");
+                            response.getWriter().write(
+                                    "{\"message\":\"카카오 로그인에 실패했습니다.\"}");
+                        })
                 )
                 .securityContext(context -> context.requireExplicitSave(false)); // 인증 상태 유지 설정
         return http.build();

--- a/src/main/java/com/book/book_log/controller/AuthController.java
+++ b/src/main/java/com/book/book_log/controller/AuthController.java
@@ -25,6 +25,10 @@ public class AuthController {
     // 카카오 로그인 성공 리디렉션 처리
     @GetMapping("/kakao-login/success")
     public ResponseEntity<Void> kakaoLoginSuccess(OAuth2AuthenticationToken authenticationToken) {
+        // 로그인 흐름을 거치지 않고 직접 호출하면 토큰이 없다
+        if (authenticationToken == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
         try {
             OAuth2AuthorizedClient authorizedClient = authorizedClientSvc.loadAuthorizedClient(
                     authenticationToken.getAuthorizedClientRegistrationId(),

--- a/src/main/resources/application.properties.example
+++ b/src/main/resources/application.properties.example
@@ -1,0 +1,38 @@
+## application.properties 템플릿.
+## 이 파일을 application.properties로 복사한 뒤 <> 부분을 채운다. (원본은 gitignore 대상)
+##
+## redirect-uri는 아래 템플릿 그대로 둘 것. 경로를 직접 지어 쓰면 스프링 시큐리티의
+## 콜백 필터 경로(/login/oauth2/code/{registrationId})와 어긋나 KOE006이 난다. (이슈 #78)
+## 카카오는 스프링이 아는 제공자가 아니라 이 항목을 생략하면 기동이 실패한다.
+## 카카오 개발자 콘솔에는 http://localhost:8080/login/oauth2/code/kakao 를 등록한다.
+
+spring.application.name=book-log
+
+# PostgreSQL (docker compose up -d)
+spring.datasource.url=jdbc:postgresql://localhost:5432/booklog
+spring.datasource.username=bookloguser
+spring.datasource.password=booklog
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+spring.sql.init.mode=never
+
+springdoc.api-docs.enabled=true
+springdoc.swagger-ui.enabled=true
+
+# Kakao OAuth
+spring.security.oauth2.client.registration.kakao.client-id=<카카오 REST API 키>
+spring.security.oauth2.client.registration.kakao.redirect-uri={baseUrl}/login/oauth2/code/{registrationId}
+spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.kakao.scope=profile_nickname
+
+spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
+spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
+spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
+spring.security.oauth2.client.provider.kakao.user-name-attribute=id
+
+# Aladin API
+aladin.api.key=<알라딘 TTB 키>
+aladin.api.base-url=https://www.aladin.co.kr/ttb/api/


### PR DESCRIPTION
# PR 유형

- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩터링 (refactor)
- [ ] 문서/설정 (docs/chore)
- [ ] 테스트 (test)

## 개요

카카오 로그인이 KOE006으로 막혀 있던 문제와, 그 과정에서 드러난 인증 관련 결함들을 함께 고쳤습니다.
로그인 성공 → DB에 사용자 저장까지 실제로 확인했습니다.

## 변경 사항

**1. 카카오 로그인 Redirect URI 불일치** — `redirect-uri`가 `/api/auth/kakao-login/callback`으로 지정돼 있었는데, 이 경로는 카카오 콘솔에도 미등록이고 우리 앱에도 처리기가 없었습니다. 스프링 시큐리티의 OAuth2 콜백 필터는 기본 경로인 `/login/oauth2/code/kakao`에서 대기 중이라 애초에 어긋난 설정이었습니다. 템플릿(`{baseUrl}/login/oauth2/code/{registrationId}`)으로 되돌렸습니다.

설정 파일이 gitignore 대상이라 이 수정이 레포에 남지 않으므로 `application.properties.example`을 추가했습니다.

**2. 프론트 진입점 오류** (`Header.jsx`) — 콜백 URL로 이동시키고 있었습니다. 인가 코드 없이 필터에 걸려 실패 처리로 넘어갔고, 그 결과 스프링 기본 로그인 페이지("Login with OAuth 2.0 / invalid_request / kakao")가 떴습니다. 거기 kakao 링크를 누르면 로그인이 되던 게 이 때문입니다. `Login.jsx`와 동일한 진입점으로 맞췄습니다.

**3. 로그인 실패 응답** — `failureUrl`로 지정한 경로는 `DefaultLoginPageGeneratingFilter`가 가로채서 `DispatcherServlet`까지 가지 않습니다. 컨트롤러에 핸들러를 만들어도 무시됩니다. `failureHandler`로 교체해 401 + JSON을 직접 반환합니다.

**4. `/kakao-login/success` 직접 호출 시 500** — 로그인 흐름을 거치지 않으면 `OAuth2AuthenticationToken`이 null인데 그대로 호출해 NPE가 났습니다. 401로 처리합니다.

**5. Swagger 진입 경로** — permitAll에 `/swagger-ui/**`는 있는데 `/swagger-ui.html`이 없었습니다. 둘은 별개로 매칭돼서 **어느 URL로 들어오냐에 따라 인증 요구 여부가 달라지는** 상태였습니다. `/swagger-ui.html`을 추가했습니다.

## 테스트

- [x] `./gradlew test --rerun-tasks` 통과
- [x] 브라우저에서 카카오 로그인 성공 → `users` 테이블에 사용자 저장 확인
- [x] 잘못된 code로 콜백 호출 → `401` + `{"message":"카카오 로그인에 실패했습니다."}`
- [x] `/api/auth/kakao-login/success` 직접 호출 → `401` (기존 500)
- [x] `/swagger-ui.html` → `302 → /swagger-ui/index.html`, 인증 안 걸림
- [x] `/oauth2/authorization/kakao`의 `redirect_uri` = `http://localhost:8080/login/oauth2/code/kakao`

## 배운 점 / 결정 사항

- **`failureUrl` vs `failureHandler`**: 처음엔 `AuthController`에 `/kakao-login/failure` 핸들러를 추가했는데 계속 기본 로그인 페이지가 나왔습니다. 같은 하위 경로인 `/kakao-login/nonexistent`는 302가 나오는데 `/failure`만 로그인 페이지가 나오는 걸로 원인을 좁혔습니다. `failureUrl`로 지정하면 스프링 시큐리티가 그 경로를 자기 것으로 등록해 필터 단계에서 처리합니다. API 서버라면 리다이렉트 대신 `failureHandler`로 응답을 직접 쓰는 쪽이 맞습니다.
- **설정 파일이 gitignore면 결정도 사라진다**: 이번 버그의 근본 원인이 gitignore된 파일의 한 줄이라 히스토리도 없고 재발을 막을 방법도 없었습니다. `.example` 템플릿이 그 자리를 메웁니다.
- **디버깅은 문서 → 관측 순서**: KOE006은 카카오 공식 문서에 "리다이렉트 URI가 올바르지 않은 경우"라고 명시돼 있었고, 실제로 앱이 뭘 보내는지는 `/oauth2/authorization/kakao`의 Location 헤더로 확인했습니다. 설정 파일만 읽고 추측했으면 못 찾았을 문제입니다.

## 후속 작업

- 지금 테스트는 `contextLoads()` 하나뿐이라 이 PR의 변경을 아무것도 검증하지 못합니다. 인증 관련 슬라이스 테스트가 필요합니다
- `AuthController`가 예외를 `e.printStackTrace()`로 처리 중입니다. `@RestControllerAdvice` 기반 표준화 대상입니다

## 관련 이슈

closes #78
