### PR TITLE
feat/jwt-httponly-cookie; JWT를 HttpOnly 쿠키로 전달, 서명 키 분리, 로그인 간헐적 실패 수정

### DIFF
--- a/src/main/frontend/src/booklog/Writelog.jsx
+++ b/src/main/frontend/src/booklog/Writelog.jsx
@@ -195,7 +195,6 @@ function Writelog({ maxStars = 5, onRatingChange }) {
     // const navigate = useNavigate();
     const { id } = useParams();
     const userId = localStorage.getItem("userId");
-    const accessToken = localStorage.getItem("accessToken");
 
     const [bookData, setBookData] = useState(null);
 
@@ -247,7 +246,7 @@ function Writelog({ maxStars = 5, onRatingChange }) {
     };
 
     const handleSubmit = async () => {
-        if (!accessToken || !userId) {
+        if (!userId) {
             alert("로그인이 필요합니다.");
             return;
         }
@@ -269,13 +268,7 @@ function Writelog({ maxStars = 5, onRatingChange }) {
         console.log(requestBody);
 
         try {
-            await axios.post(`/api/logs/${userId}`, requestBody, 
-            {
-                headers : {Authorization : `Bearer ${accessToken}`},
-                withCredentials : true,
-            }
-            
-        )
+            await axios.post(`/api/logs/${userId}`, requestBody, { withCredentials : true })
         } catch (error) {
             console.error("에러 발생:", error);
         }

--- a/src/main/frontend/src/header/Header.jsx
+++ b/src/main/frontend/src/header/Header.jsx
@@ -55,22 +55,18 @@ function Header() {
     const navigate = useNavigate();
     const dispatch = useDispatch();
     const isLoggedIn = useSelector((state) => state.auth.isLoggedIn);
-    const [localStorageToken, setLocalStorageToken] = useState(localStorage.getItem("accessToken"));
+    const [storedUserId, setStoredUserId] = useState(localStorage.getItem("userId"));
 
     useEffect(() => {
-        // 로그인 여부를 LocalStorage에서 확인
-        const accessToken = localStorage.getItem("accessToken");
-        setLocalStorageToken(accessToken);
+        const userId = localStorage.getItem("userId");
+        setStoredUserId(userId);
 
-        console.log("현재 토큰:", accessToken);
-        console.log("redux 상태 : ", isLoggedIn);
-
-        if (accessToken) {
+        if (userId) {
             dispatch(login());
         } else {
             dispatch(logout());
         }
-    }, [dispatch, localStorageToken]);
+    }, [dispatch, storedUserId]);
 
     const navigateToHome = () => {
         navigate("/");

--- a/src/main/frontend/src/login/AddInformation.jsx
+++ b/src/main/frontend/src/login/AddInformation.jsx
@@ -180,13 +180,7 @@ function AddInformation() {
             return;
         }
         
-        try { //쿠키에서 토큰 가져오기
-            const accessToken = localStorage.getItem("accessToken");
-            if (!accessToken) {
-                console.error("인증 정보 없음");
-                navigate("/login");
-                return;
-            }
+        try {
             let userId = kakaoId || localStorage.getItem("userId");
             if (!userId) {
                 console.error("사용자 정보 없음");
@@ -194,17 +188,13 @@ function AddInformation() {
                 return;
             }
             const response = await axios.put(
-                `http://localhost:8080/api/users/${userId}`,
+                `/api/users/${userId}`,
                 {
                     nickname : formData.nickname,
                     gender : formData.gender,
                     ageGroup : formData.ageGroup,
                 },
-                {
-                    headers : {Authorization : `Bearer ${accessToken}`},
-                    withCredentials : true,
-                }
-
+                { withCredentials : true }
             );
             console.log("사용자 정보 업데이트 성공 : ",response.data);
             navigate("/home");

--- a/src/main/frontend/src/login/Redirect.jsx
+++ b/src/main/frontend/src/login/Redirect.jsx
@@ -8,34 +8,21 @@ function Redirect() {
     const dispatch = useDispatch();
 
     useEffect(() => {
-        console.log("현재 URL : ", window.location.href);
-        
+        // JWT는 HttpOnly 쿠키로 들어와 있어 JS에서 읽지 않는다
         const params = new URLSearchParams(window.location.search);
-        const token = params.get("token");
         const userId = params.get("userId");
         const isNewUser = params.get("isNewUser");
 
-        console.log("저장할 토큰 : ",token);
-
-        if (token && userId) {
-            localStorage.setItem("accessToken", token);
-            localStorage.setItem("userId", userId);
-            console.log("저장된 토큰: ", localStorage.getItem("accessToken"));
-
-            dispatch(login()); //redux 로그인상태 업데이트
-
-            setTimeout(()=>{
-                if (isNewUser === "true") {
-                    navigate("/addinformation");
-                } else {
-                    navigate("/");
-                }
-            }, 500);
-
-        } else {
-            console.error("카카오 로그인 실패 또는 토큰 누락");
-            navigate("/login"); // 실패 시 로그인 페이지로 리다이렉션
+        if (!userId) {
+            console.error("카카오 로그인 실패");
+            navigate("/login");
+            return;
         }
+
+        localStorage.setItem("userId", userId);
+        dispatch(login()); //redux 로그인상태 업데이트
+
+        navigate(isNewUser === "true" ? "/addinformation" : "/");
     }, [navigate, dispatch]);
 
     return (

--- a/src/main/frontend/src/mypage/Mypage.jsx
+++ b/src/main/frontend/src/mypage/Mypage.jsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from "react";
+import axios from "axios";
 import styled from "styled-components";
 import image1 from "./image1.png";
 import image from "./image.png";
 import Modal from "../component/Modal";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Button, SubmitButton } from "../component/Button";
 import { useDispatch } from "react-redux";
 import { logout } from "../redux/authSlice";
@@ -127,7 +128,8 @@ const ModalButtonContainer = styled.div`
 function Mypage() {
     const navigate = useNavigate();
     const dispatch = useDispatch();
-    const { id } = useParams();
+    // /mypage 라우트에는 경로 변수가 없다. 로그인 시 저장해둔 값을 쓴다.
+    const id = localStorage.getItem("userId");
 
     const [formData, setFormData ] = useState({
         nickname : "",
@@ -139,6 +141,10 @@ function Mypage() {
     const [nicknameError, setNicknameError] = useState("");
     
     useEffect(() => { //기본값이 GET
+        if (!id) {
+            navigate("/login");
+            return;
+        }
         fetch(`/api/users/${id}`)
             .then((res) => res.json())
             .then((data) => {
@@ -149,7 +155,7 @@ function Mypage() {
                 });
             })
             .catch((err) => console.error("Error : ",err));
-    },[id]);
+    },[id, navigate]);
 
     const handleNinknameChange = async (e) => {
         const newNickname = e.target.value;
@@ -179,9 +185,14 @@ function Mypage() {
     };
 
     const handleLogout = async () => {
-        localStorage.removeItem("accessToken");
-        localStorage.removeItem("userId");
+        // 쿠키는 서버만 지울 수 있다
+        try {
+            await axios.post("/api/auth/logout");
+        } catch (error) {
+            console.error("로그아웃 요청 실패 : ", error);
+        }
 
+        localStorage.removeItem("userId");
         dispatch(logout());
 
         alert("로그아웃되었습니다.");

--- a/src/main/frontend/src/redux/authSlice.js
+++ b/src/main/frontend/src/redux/authSlice.js
@@ -1,7 +1,9 @@
 import { createSlice } from "@reduxjs/toolkit";
 
+// JWT는 HttpOnly 쿠키라 JS에서 못 읽는다. 화면 표시용 상태만 userId로 판단하고
+// 실제 인증 여부는 서버가 판정한다.
 const initialState = {
-    isLoggedIn : !!localStorage.getItem("accessToken"), //기본값 : 로그아웃 상태
+    isLoggedIn : !!localStorage.getItem("userId"),
 };
 
 const authSlice = createSlice({
@@ -13,8 +15,7 @@ const authSlice = createSlice({
         },
         logout : (state) => {
             state.isLoggedIn = false;
-            localStorage.removeItem("accessToken");
-            
+            localStorage.removeItem("userId");
         },
     },
 });

--- a/src/main/java/com/book/book_log/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/book/book_log/config/JwtAuthenticationFilter.java
@@ -1,8 +1,10 @@
 package com.book.book_log.config;
 
+import com.book.book_log.util.JwtCookieFactory;
 import com.book.book_log.util.JwtUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -11,9 +13,16 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -24,27 +33,40 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
-        // JWT 토큰 처리
-        String header = request.getHeader("Authorization");
-        if (header != null && header.startsWith("Bearer")) {
-            String token = header.substring(7); // "Bearer " 이후의 토큰 값
+        String token = resolveToken(request);
+        if (token != null) {
             try {
-                System.out.println("Extracted Token: " + token); // 디버깅 로그: 토큰 확인
-                String userId = JwtUtil.validateToken(token); // JWT 검증 및 userId 추출
-                System.out.println("Validated UserId: " + userId); // 디버깅 로그: 검증된 userId
+                String userId = jwtUtil.validateToken(token); // JWT 검증 및 userId 추출
 
                 // SecurityContext에 인증 정보 저장
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(userId, null, List.of(new SimpleGrantedAuthority("USER")));
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             } catch (RuntimeException e) {
-                System.err.println("JWT Validation Error: " + e.getMessage()); // 디버깅 로그: 예외 메시지
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                response.getWriter().write("Invalid JWT token");
+                response.setContentType("application/json;charset=UTF-8");
+                response.getWriter().write("{\"message\":\"유효하지 않거나 만료된 토큰입니다.\"}");
                 return;
             }
         }
 
         filterChain.doFilter(request, response); // 다음 필터로 이동
+    }
+
+    // 브라우저는 쿠키로, Swagger·Postman 같은 도구는 헤더로 보낸다
+    private String resolveToken(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith("Bearer ")) {
+            return header.substring(7);
+        }
+        if (request.getCookies() == null) {
+            return null;
+        }
+        return Arrays.stream(request.getCookies())
+                .filter(c -> JwtCookieFactory.COOKIE_NAME.equals(c.getName()))
+                .map(Cookie::getValue)
+                .filter(v -> !v.isBlank())
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/com/book/book_log/config/SecurityConfig.java
+++ b/src/main/java/com/book/book_log/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.book.book_log.config;
 
+import com.book.book_log.util.JwtUtil;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +11,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 public class SecurityConfig {
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtUtil jwtUtil) throws Exception {
         http
                 .csrf(csrf -> csrf.disable()) // CSRF 비활성화
                 .authorizeHttpRequests(auth -> auth
@@ -28,9 +29,11 @@ public class SecurityConfig {
                         ).permitAll()                // 인증 없이 허용
                         .anyRequest().authenticated()    // 나머지 요청은 인증 필요
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class) // 필터 추가
+                .addFilterBefore(new JwtAuthenticationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class) // 필터 추가
                 .oauth2Login(oauth2 -> oauth2
-                        .defaultSuccessUrl("/api/auth/kakao-login/success") // 로그인 성공 시 리다이렉트 경로
+                        // true: 인증 전에 막힌 요청이 저장돼 있어도 무시하고 항상 이 경로로 보낸다.
+                        // 저장된 요청으로 가버리면 JWT 쿠키를 발급하는 핸들러가 실행되지 않는다.
+                        .defaultSuccessUrl("/api/auth/kakao-login/success", true)
                         // failureUrl로 지정한 경로는 DefaultLoginPageGeneratingFilter가 가로채
                         // 기본 로그인 페이지를 렌더하므로 컨트롤러에 도달하지 않는다
                         .failureHandler((request, response, exception) -> {

--- a/src/main/java/com/book/book_log/controller/AuthController.java
+++ b/src/main/java/com/book/book_log/controller/AuthController.java
@@ -2,8 +2,10 @@ package com.book.book_log.controller;
 
 import com.book.book_log.dto.UserResponseDTO;
 import com.book.book_log.service.CustomOAuth2UserService;
+import com.book.book_log.util.JwtCookieFactory;
 import com.book.book_log.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -21,6 +23,8 @@ import java.net.URI;
 public class AuthController {
     private final CustomOAuth2UserService oAuth2uSvc;
     private final OAuth2AuthorizedClientService authorizedClientSvc;
+    private final JwtCookieFactory jwtCookieFactory;
+    private final JwtUtil jwtUtil;
 
     // 카카오 로그인 성공 리디렉션 처리
     @GetMapping("/kakao-login/success")
@@ -38,13 +42,14 @@ public class AuthController {
             OAuth2AccessToken accessToken = authorizedClient.getAccessToken();
 
             UserResponseDTO user = oAuth2uSvc.processOAuth2User(authenticationToken, accessToken);
-            String jwt = JwtUtil.generateToken(user.getId());
+            String jwt = jwtUtil.generateToken(user.getId());
 
-            // 프론트엔드로 JWT와 userId를 쿼리스트링으로 전달
-            String redirectUrl = String.format("http://localhost:3000/oauth/kakao/success?token=%s&userId=%s",
-                    jwt, user.getId());
+            // JWT는 HttpOnly 쿠키로만 전달한다. 주소창에 실으면 히스토리·액세스 로그에 남는다.
+            String redirectUrl = String.format("http://localhost:3000/oauth/kakao/success?userId=%s",
+                    user.getId());
 
             return ResponseEntity.status(HttpStatus.FOUND)
+                    .header(HttpHeaders.SET_COOKIE, jwtCookieFactory.create(jwt).toString())
                     .location(URI.create(redirectUrl))
                     .build();
         } catch (Exception e) {
@@ -59,14 +64,16 @@ public class AuthController {
         if (user.getId() == null || user.getId().isEmpty()) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("User ID is required");
         }
-        String jwtToken = JwtUtil.generateToken(user.getId());
+        String jwtToken = jwtUtil.generateToken(user.getId());
         return ResponseEntity.ok(jwtToken);
     }
 
     // 로그아웃
     @PostMapping("/logout")
     public ResponseEntity<String> logout() {
-        SecurityContextHolder.clearContext(); // 인증 정보 초기화
-        return ResponseEntity.ok("성공적으로 로그아웃 되었습니다."); // 로그아웃 성공 메시지 반환
+        SecurityContextHolder.clearContext();
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, jwtCookieFactory.expire().toString())
+                .body("성공적으로 로그아웃 되었습니다.");
     }
 }

--- a/src/main/java/com/book/book_log/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/book/book_log/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.book.book_log.exception;
 
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -9,6 +10,11 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<String> handleEntityNotFoundException(EntityNotFoundException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
     }
 }

--- a/src/main/java/com/book/book_log/util/JwtCookieFactory.java
+++ b/src/main/java/com/book/book_log/util/JwtCookieFactory.java
@@ -1,0 +1,39 @@
+package com.book.book_log.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class JwtCookieFactory {
+
+    public static final String COOKIE_NAME = "accessToken";
+
+    private final JwtUtil jwtUtil;
+
+    // 배포(HTTPS) 환경에서는 true로 올린다
+    @Value("${app.auth.cookie-secure:false}")
+    private boolean secure;
+
+    public ResponseCookie create(String token) {
+        return build(token, Duration.ofMillis(jwtUtil.getExpirationMs()));
+    }
+
+    public ResponseCookie expire() {
+        return build("", Duration.ZERO);
+    }
+
+    private ResponseCookie build(String value, Duration maxAge) {
+        return ResponseCookie.from(COOKIE_NAME, value)
+                .httpOnly(true)
+                .secure(secure)
+                .sameSite("Lax") // 다른 사이트에서 시작된 요청에는 쿠키를 붙이지 않는다 (CSRF 방어)
+                .path("/")
+                .maxAge(maxAge)
+                .build();
+    }
+}

--- a/src/main/java/com/book/book_log/util/JwtUtil.java
+++ b/src/main/java/com/book/book_log/util/JwtUtil.java
@@ -5,28 +5,41 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
 
+@Component
 public class JwtUtil {
-    private static final String SECRET_KEY = "mySuperSecretKey1234567890mySuperSecretKey12345"; // 256비트
-    private static final long EXPIRATION_TIME = 1000 * 60 * 60; // 1시간
 
-    private static final Key KEY = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
+    private final Key key;
+    private final long expirationMs;
 
-    public static String generateToken(String userId) {
+    public JwtUtil(@Value("${app.jwt.secret}") String secret,
+                   @Value("${app.jwt.expiration-ms:3600000}") long expirationMs) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expirationMs = expirationMs;
+    }
+
+    public long getExpirationMs() {
+        return expirationMs;
+    }
+
+    public String generateToken(String userId) {
         return Jwts.builder()
                 .setSubject(userId)
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
-                .signWith(KEY, SignatureAlgorithm.HS256)
+                .setExpiration(new Date(System.currentTimeMillis() + expirationMs))
+                .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
 
-    public static String validateToken(String token) {
+    public String validateToken(String token) {
         try {
-            Claims claims = Jwts.parserBuilder().setSigningKey(KEY).build().parseClaimsJws(token).getBody();
+            Claims claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
             return claims.getSubject();
         } catch (JwtException e) {
             throw new RuntimeException("유효하지 않거나 만료된 토큰입니다.");

--- a/src/main/resources/application.properties.example
+++ b/src/main/resources/application.properties.example
@@ -19,6 +19,10 @@ spring.jpa.properties.hibernate.format_sql=true
 
 spring.sql.init.mode=never
 
+# JWT 서명 키. 이 값을 아는 사람은 임의의 사용자로 토큰을 위조할 수 있으므로
+# 절대 커밋하지 않는다. 생성: openssl rand -base64 48
+app.jwt.secret=<32바이트 이상 랜덤 문자열>
+
 springdoc.api-docs.enabled=true
 springdoc.swagger-ui.enabled=true
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -4,6 +4,8 @@ spring.application.name=book-log
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.sql.init.mode=never
 
+app.jwt.secret=test-secret-key-for-local-tests-only-do-not-use-in-real
+
 # 컨텍스트 로드용 더미 값. 실제 인증/호출은 하지 않는다.
 spring.security.oauth2.client.registration.kakao.client-id=test-client-id
 spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:8080/api/auth/kakao-login/callback


### PR DESCRIPTION
# PR 유형

- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩터링 (refactor)
- [ ] 문서/설정 (docs/chore)
- [ ] 테스트 (test)

## 개요

JWT 전달 방식을 쿼리스트링에서 HttpOnly 쿠키로 바꿉니다. 작업 중 확인된 서명 키 노출과 카카오 로그인 간헐적 실패도 같이 처리했습니다.

## 변경 사항

### 1. JWT 서명 키가 소스에 하드코딩돼 공개 노출 (`b703d4e`)

`JwtUtil.SECRET_KEY`가 소스에 상수로 박혀 있어 공개 레포에 그대로 올라가 있었습니다. 이 값을 아는 쪽은 **토큰을 훔칠 필요 없이 임의의 `userId`로 유효한 JWT를 직접 만들 수 있습니다.** 인증 체계 전체가 무력화되는 상태였습니다.

- `JwtUtil`을 static 유틸에서 스프링 빈으로 전환하고 키를 `app.jwt.secret` 설정으로 분리
- 노출된 키는 무효화. 각 환경에서 `openssl rand -base64 48`로 새로 생성해 사용
- 히스토리에 남은 옛 값은 제거할 수 없으므로 **값 교체로 무효화**하는 방식을 택함
- 기존 발급 토큰은 모두 무효가 되며 재로그인이 필요

### 2. JWT 전달 방식 변경 (`2c12950`) — closes #80

쿼리스트링으로 넘기면 브라우저 히스토리, 서버 액세스 로그, Referer에 토큰이 남습니다. 프론트는 이를 `localStorage`에 저장해 XSS 시 한 줄로 탈취됩니다.

- 인증 성공 시 `HttpOnly` + `SameSite=Lax` 쿠키로 발급, 주소창에는 `userId`만 전달
- `JwtAuthenticationFilter`가 쿠키에서 토큰을 읽음. Swagger·Postman 용도로 `Authorization` 헤더도 계속 지원
- 로그아웃이 서버에 요청을 보내 쿠키를 만료시킴 (쿠키는 서버만 제거 가능)
- 필터가 서버 로그에 토큰 전문을 출력하던 `System.out.println` 제거
- 쿠키 `secure` 플래그는 `app.auth.cookie-secure`로 분리 (로컬 http는 false, 배포 시 true)

프론트가 CRA 프록시로 상대경로를 호출해 브라우저에는 동일 출처로 보이므로 쿠키가 자동 전송됩니다. CORS 설정 변경은 불필요했습니다.

### 3. 카카오 로그인 간헐적 실패 (`2c12950`, `7497113`, `b29ce1f`)

`/api/users/undefined?continue` 요청이 500으로 실패하는 현상이 있었습니다. 원인이 세 개 연쇄였습니다.

- **`Mypage.jsx`가 존재하지 않는 경로 변수를 사용** — `/mypage` 라우트에 경로 변수가 없는데 `useParams()`로 `id`를 꺼내 항상 `undefined`였고, 템플릿 리터럴에서 문자열 `"undefined"`로 변환돼 `/api/users/undefined`를 호출. 저장된 userId를 쓰도록 변경
- **`defaultSuccessUrl`에 `alwaysUse`가 없었음** — 인자 하나짜리는 "저장된 요청이 없을 때만" 해당 경로를 씁니다. 위 요청이 세션에 저장돼 있으면 로그인 성공 후 그쪽으로 리다이렉트되고, **JWT 쿠키를 발급하는 성공 핸들러가 실행되지 않습니다.** `alwaysUse=true`로 변경
- **`EntityNotFoundException` 미처리** — `GlobalExceptionHandler`가 `IllegalArgumentException`만 다뤄 없는 리소스 조회가 404가 아닌 500으로 나감

세 개를 모두 고쳐야 합니다. 경로 변수만 고치면 다른 보호된 요청이 저장될 때 같은 일이 반복되고, `alwaysUse`만 고치면 404가 500으로 나가는 문제가 남습니다.

## 테스트

- [x] `./gradlew test --rerun-tasks` 통과
- [x] 카카오 로그인 성공. 주소창에 `token=`이 없고 `userId=`만 남음
- [x] `accessToken` 쿠키가 HttpOnly로 설정됨. `document.cookie`로 조회되지 않음
- [x] 마이페이지를 먼저 방문한 뒤 로그인하는 경로에서도 정상 동작 (기존 500 재현 경로)
- [x] 로그아웃 후 쿠키 제거 확인
- [x] 프론트 전체에 `accessToken` 참조 및 토큰 관련 `console.log` 잔존 없음

## 배운 점 / 결정 사항

- **`?continue`가 원인 추적의 단서였습니다.** 스프링 시큐리티가 저장된 요청을 재생할 때 붙이는 표식이라, 요청 URL만 보고도 "인증 전에 막힌 요청이 로그인 후 재생됐다"는 경로를 특정할 수 있었습니다.
- **`defaultSuccessUrl(url)`과 `defaultSuccessUrl(url, true)`는 의미가 다릅니다.** 전자는 저장된 요청이 우선입니다. 성공 핸들러에서 토큰 발급 같은 필수 작업을 한다면 반드시 후자여야 합니다. 이 조합은 "특정 화면을 거쳐 로그인할 때만" 실패해서 간헐적으로 보입니다.
- **HttpOnly 쿠키 vs localStorage는 방어 대상이 다릅니다.** 쿠키는 XSS로 읽을 수 없는 대신 자동 전송되어 CSRF에 노출되고, localStorage는 그 반대입니다. XSS는 사용자 입력을 렌더하는 모든 지점에서 발생 가능한 반면 CSRF는 `SameSite` 한 줄로 대부분 차단되므로 쿠키를 선택했습니다.
- **유출된 자격증명은 제거보다 무효화가 먼저입니다.** 히스토리 재작성으로 지우려 시도하기 전에 값을 교체하면 유출본은 즉시 무가치해집니다.
- **세 결함 모두 조용히 실패하고 있었습니다.** 프론트는 `catch`에서 콘솔에만 남기고, 간헐적 500은 새로고침하면 사라지고, 노출된 키는 아무 증상이 없습니다.

## 후속 작업

- 이 PR은 인증 경로를 광범위하게 변경했지만 자동 테스트는 `contextLoads()` 하나뿐이라 변경 내용을 검증하지 못합니다. 인증 슬라이스 테스트가 필요합니다
- 배포 시 `app.auth.cookie-secure=true`, 프론트와 백엔드 도메인이 분리되면 `SameSite=None` 및 CORS `allowCredentials` 설정 필요
- `AuthController`가 예외를 `e.printStackTrace()`로 처리하는 부분이 남아 있습니다

## 관련 이슈

closes #80
